### PR TITLE
Add keybind to disable inventory tabs

### DIFF
--- a/src/main/java/folk/sisby/inventory_tabs/ControlHintToast.java
+++ b/src/main/java/folk/sisby/inventory_tabs/ControlHintToast.java
@@ -38,6 +38,6 @@ public class ControlHintToast implements Toast {
 
     @Override
     public int getWidth() {
-        return Math.max(titleWidth, hintWidth) + 16;
+        return Math.max(titleWidth, hintWidth) + 24;
     }
 }

--- a/src/main/java/folk/sisby/inventory_tabs/ControlHintToast.java
+++ b/src/main/java/folk/sisby/inventory_tabs/ControlHintToast.java
@@ -1,30 +1,43 @@
 package folk.sisby.inventory_tabs;
 
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.toast.Toast;
 import net.minecraft.client.toast.ToastManager;
 import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
 
 public class ControlHintToast implements Toast {
     protected Text title;
     protected Text keyHint;
     protected KeyBinding keyBinding;
+    protected int titleWidth;
+    protected int hintWidth;
 
     public ControlHintToast(Text title, KeyBinding keybinding)
     {
         this.title = title;
         this.keyBinding = keybinding;
-        keyHint = keyBinding.getBoundKeyLocalizedText();
+        keyHint = Text.translatable("toast.inventory_tabs.disabled.key_hint", keyBinding.getBoundKeyLocalizedText().copy().formatted(Formatting.YELLOW)).formatted(Formatting.BLUE);
+        titleWidth = MinecraftClient.getInstance().textRenderer.getWidth(title);
+        hintWidth = MinecraftClient.getInstance().textRenderer.getWidth(keyHint);
     }
 
 
     @Override
-    public Visibility draw(DrawContext context, ToastManager manager, long startTime) {
+    public Visibility draw(DrawContext context, ToastManager manager, long elapsedTime) {
         context.drawNineSlicedTexture(TEXTURE, 0, 0, getWidth(), getHeight(), 4, 160, 32, 0, 0);
-        context.drawText(manager.getClient().textRenderer, title, 32, 7, 0xFFFFFF, false);
-        context.drawText(manager.getClient().textRenderer, keyHint, 32, 18, 0xFFFFFF, false);
+        context.drawText(manager.getClient().textRenderer, title, (getWidth() - titleWidth)/2, 7, 0xFFFFFF, false);
+        context.drawText(manager.getClient().textRenderer, keyHint, (getWidth() - hintWidth)/2, 18, 0xFFFFFF, false);
 
-        return Visibility.SHOW;
+        double time = 2000 * manager.getNotificationDisplayTimeMultiplier();
+
+        return elapsedTime >= time ? Visibility.HIDE : Visibility.SHOW;
+    }
+
+    @Override
+    public int getWidth() {
+        return Math.max(titleWidth, hintWidth) + 16;
     }
 }

--- a/src/main/java/folk/sisby/inventory_tabs/ControlHintToast.java
+++ b/src/main/java/folk/sisby/inventory_tabs/ControlHintToast.java
@@ -1,0 +1,30 @@
+package folk.sisby.inventory_tabs;
+
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.option.KeyBinding;
+import net.minecraft.client.toast.Toast;
+import net.minecraft.client.toast.ToastManager;
+import net.minecraft.text.Text;
+
+public class ControlHintToast implements Toast {
+    protected Text title;
+    protected Text keyHint;
+    protected KeyBinding keyBinding;
+
+    public ControlHintToast(Text title, KeyBinding keybinding)
+    {
+        this.title = title;
+        this.keyBinding = keybinding;
+        keyHint = keyBinding.getBoundKeyLocalizedText();
+    }
+
+
+    @Override
+    public Visibility draw(DrawContext context, ToastManager manager, long startTime) {
+        context.drawNineSlicedTexture(TEXTURE, 0, 0, getWidth(), getHeight(), 4, 160, 32, 0, 0);
+        context.drawText(manager.getClient().textRenderer, title, 32, 7, 0xFFFFFF, false);
+        context.drawText(manager.getClient().textRenderer, keyHint, 32, 18, 0xFFFFFF, false);
+
+        return Visibility.SHOW;
+    }
+}

--- a/src/main/java/folk/sisby/inventory_tabs/InventoryTabs.java
+++ b/src/main/java/folk/sisby/inventory_tabs/InventoryTabs.java
@@ -18,6 +18,7 @@ public class InventoryTabs implements ClientModInitializer {
     public static final InventoryTabsConfig CONFIG = InventoryTabsConfig.createToml(FabricLoader.getInstance().getConfigDir(), "", ID, InventoryTabsConfig.class);
 
     public static KeyBinding NEXT_TAB;
+    public static KeyBinding TOGGLE_TABS;
 
     public static Identifier id(String path) {
         return new Identifier(ID, path);
@@ -31,6 +32,12 @@ public class InventoryTabs implements ClientModInitializer {
                 "key.inventory_tabs.key.next_tab",
                 InputUtil.Type.KEYSYM,
                 GLFW.GLFW_KEY_TAB,
+                "key.categories.inventory"
+        ));
+        TOGGLE_TABS = KeyBindingHelper.registerKeyBinding(new KeyBinding(
+                "key.inventory_tabs.key.toggle_tabs",
+                InputUtil.Type.KEYSYM,
+                GLFW.GLFW_KEY_LEFT_BRACKET,
                 "key.categories.inventory"
         ));
     }

--- a/src/main/java/folk/sisby/inventory_tabs/TabManager.java
+++ b/src/main/java/folk/sisby/inventory_tabs/TabManager.java
@@ -224,6 +224,10 @@ public class TabManager {
     }
 
     public static boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+        if (InventoryTabs.TOGGLE_TABS.matchesKey(keyCode, scanCode))
+        {
+            MinecraftClient.getInstance().getToastManager().add(new ControlHintToast(Text.literal("Tabs Toggled"), InventoryTabs.TOGGLE_TABS));
+        }
         if (holdTabCooldown <= 0 && nextTab == null && InventoryTabs.NEXT_TAB.matchesKey(keyCode, scanCode)) {
             holdTabCooldown = InventoryTabs.CONFIG.holdTabCooldown;
             if (Screen.hasShiftDown()) {

--- a/src/main/java/folk/sisby/inventory_tabs/TabManager.java
+++ b/src/main/java/folk/sisby/inventory_tabs/TabManager.java
@@ -1,11 +1,7 @@
 package folk.sisby.inventory_tabs;
 
 import folk.sisby.inventory_tabs.duck.InventoryTabsScreen;
-import folk.sisby.inventory_tabs.tabs.BlockTab;
-import folk.sisby.inventory_tabs.tabs.EntityTab;
-import folk.sisby.inventory_tabs.tabs.ItemTab;
-import folk.sisby.inventory_tabs.tabs.Tab;
-import folk.sisby.inventory_tabs.tabs.VehicleInventoryTab;
+import folk.sisby.inventory_tabs.tabs.*;
 import folk.sisby.inventory_tabs.util.HandlerSlotUtil;
 import folk.sisby.inventory_tabs.util.WidgetPosition;
 import net.minecraft.block.entity.BlockEntity;
@@ -34,11 +30,7 @@ import net.minecraft.util.hit.EntityHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.BiFunction;
 
 public class TabManager {
@@ -57,6 +49,7 @@ public class TabManager {
     public static Tab currentTab;
     public static List<WidgetPosition> tabPositions;
     public static int holdTabCooldown = 0;
+    public static boolean enabled = true;
 
     public static void initScreen(MinecraftClient client, HandledScreen<?> screen) {
         currentScreen = screen;
@@ -140,7 +133,8 @@ public class TabManager {
             BlockEntity blockEntity = world.getBlockEntity(pos);
             for (Tab tab : tabs) {
                 if (tab instanceof BlockTab bt) {
-                    if (pos.equals(bt.pos) || blockEntity == world.getBlockEntity(bt.pos) || bt.multiblockPositions.contains(pos)) return tab;
+                    if (pos.equals(bt.pos) || blockEntity == world.getBlockEntity(bt.pos) || bt.multiblockPositions.contains(pos))
+                        return tab;
                 }
             }
         } else if (client.crosshairTarget instanceof EntityHitResult result) {
@@ -183,7 +177,7 @@ public class TabManager {
 
     public static boolean mouseClicked(double mouseX, double mouseY, int button) {
         if (nextTab != null) return true;
-        if (button == 0) {
+        if (enabled && button == 0) {
             if (getPageButton(true).contains((int) mouseX, (int) mouseY)) {
                 if (currentPage > 0) {
                     setCurrentPage(currentPage - 1);
@@ -225,11 +219,11 @@ public class TabManager {
     }
 
     public static boolean keyPressed(int keyCode, int scanCode, int modifiers) {
-        if (InventoryTabs.TOGGLE_TABS.matchesKey(keyCode, scanCode))
-        {
-            MinecraftClient.getInstance().getToastManager().add(new ControlHintToast(Text.translatable("toast.inventory_tabs.disabled.title").formatted(Formatting.BOLD), InventoryTabs.TOGGLE_TABS));
+        if (InventoryTabs.TOGGLE_TABS.matchesKey(keyCode, scanCode)) {
+            enabled = !enabled;
+            if (!enabled) MinecraftClient.getInstance().getToastManager().add(new ControlHintToast(Text.translatable("toast.inventory_tabs.disabled.title").formatted(Formatting.BOLD), InventoryTabs.TOGGLE_TABS));
         }
-        if (holdTabCooldown <= 0 && nextTab == null && InventoryTabs.NEXT_TAB.matchesKey(keyCode, scanCode)) {
+        if (enabled && holdTabCooldown <= 0 && nextTab == null && InventoryTabs.NEXT_TAB.matchesKey(keyCode, scanCode)) {
             holdTabCooldown = InventoryTabs.CONFIG.holdTabCooldown;
             if (Screen.hasShiftDown()) {
                 if (tabs.indexOf(currentTab) == 0) {
@@ -259,24 +253,27 @@ public class TabManager {
     }
 
     public static void renderBackground(DrawContext drawContext) {
-        tabPositions = ((InventoryTabsScreen) currentScreen).getTabPositions(TAB_WIDTH);
-        for (int i = 0; i < Math.min(tabPositions.size(), tabs.size() - currentPage * tabPositions.size()); i++) {
-            WidgetPosition pos = tabPositions.get(i);
-            Tab tab = tabs.get(currentPage * tabPositions.size() + i);
-            if (pos != null && tab != null) tab.renderBackground(drawContext, pos, TAB_WIDTH, TAB_HEIGHT, tab == currentTab);
+        if (enabled) {
+            tabPositions = ((InventoryTabsScreen) currentScreen).getTabPositions(TAB_WIDTH);
+            for (int i = 0; i < Math.min(tabPositions.size(), tabs.size() - currentPage * tabPositions.size()); i++) {
+                WidgetPosition pos = tabPositions.get(i);
+                Tab tab = tabs.get(currentPage * tabPositions.size() + i);
+                if (pos != null && tab != null) tab.renderBackground(drawContext, pos, TAB_WIDTH, TAB_HEIGHT, tab == currentTab);
+            }
         }
     }
 
     public static void renderForeground(DrawContext drawContext, double mouseX, double mouseY) {
-        for (int i = 0; i < Math.min(tabPositions.size(), tabs.size() - currentPage * tabPositions.size()); i++) {
-            WidgetPosition pos = tabPositions.get(i);
-            Tab tab = tabs.get(currentPage * tabPositions.size() + i);
-            if (pos != null && tab != null) tab.renderForeground(drawContext, pos, TAB_WIDTH, TAB_HEIGHT, mouseX, mouseY,tab == currentTab);
-        }
-
-        if (getMaximumPage() > 0) {
-            drawButton(drawContext, mouseX, mouseY, true);
-            drawButton(drawContext, mouseX, mouseY, false);
+        if (enabled) {
+            for (int i = 0; i < Math.min(tabPositions.size(), tabs.size() - currentPage * tabPositions.size()); i++) {
+                WidgetPosition pos = tabPositions.get(i);
+                Tab tab = tabs.get(currentPage * tabPositions.size() + i);
+                if (pos != null && tab != null) tab.renderForeground(drawContext, pos, TAB_WIDTH, TAB_HEIGHT, mouseX, mouseY, tab == currentTab);
+            }
+            if (getMaximumPage() > 0) {
+                drawButton(drawContext, mouseX, mouseY, true);
+                drawButton(drawContext, mouseX, mouseY, false);
+            }
         }
     }
 
@@ -296,7 +293,8 @@ public class TabManager {
         int u = BUTTON_WIDTH * (left ? 0 : 1);
         int v = BUTTON_HEIGHT * (active ? hovered ? 2 : 1 : 0);
         drawContext.drawTexture(BUTTONS_TEXTURE, rect.getX(), rect.getY(), u, v, rect.getWidth(), rect.getHeight());
-        if (hovered) drawContext.drawTooltip(currentScreen.textRenderer, Text.literal((currentPage + 1) + "/" + (getMaximumPage() + 1)), (int) mouseX, (int) mouseY);
+        if (hovered)
+            drawContext.drawTooltip(currentScreen.textRenderer, Text.literal((currentPage + 1) + "/" + (getMaximumPage() + 1)), (int) mouseX, (int) mouseY);
     }
 
     public static void playClick() {

--- a/src/main/java/folk/sisby/inventory_tabs/TabManager.java
+++ b/src/main/java/folk/sisby/inventory_tabs/TabManager.java
@@ -27,6 +27,7 @@ import net.minecraft.network.packet.c2s.play.CloseHandledScreenC2SPacket;
 import net.minecraft.screen.ScreenHandler;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.hit.EntityHitResult;
@@ -226,7 +227,7 @@ public class TabManager {
     public static boolean keyPressed(int keyCode, int scanCode, int modifiers) {
         if (InventoryTabs.TOGGLE_TABS.matchesKey(keyCode, scanCode))
         {
-            MinecraftClient.getInstance().getToastManager().add(new ControlHintToast(Text.literal("Tabs Toggled"), InventoryTabs.TOGGLE_TABS));
+            MinecraftClient.getInstance().getToastManager().add(new ControlHintToast(Text.translatable("toast.inventory_tabs.disabled.title").formatted(Formatting.BOLD), InventoryTabs.TOGGLE_TABS));
         }
         if (holdTabCooldown <= 0 && nextTab == null && InventoryTabs.NEXT_TAB.matchesKey(keyCode, scanCode)) {
             holdTabCooldown = InventoryTabs.CONFIG.holdTabCooldown;

--- a/src/main/resources/assets/inventory_tabs/lang/en_us.json
+++ b/src/main/resources/assets/inventory_tabs/lang/en_us.json
@@ -1,5 +1,7 @@
 {
   "key.inventory_tabs.key.next_tab": "Next Tab",
   "key.inventory_tabs.key.toggle_tabs": "Toggle Tab Visibility",
+  "toast.inventory_tabs.disabled.title": "Tabs Disabled",
+  "toast.inventory_tabs.disabled.key_hint": "[Press %s to toggle]",
   "gui.inventory_tabs.tab.inventory": "Inventory"
 }

--- a/src/main/resources/assets/inventory_tabs/lang/en_us.json
+++ b/src/main/resources/assets/inventory_tabs/lang/en_us.json
@@ -1,4 +1,5 @@
 {
   "key.inventory_tabs.key.next_tab": "Next Tab",
+  "key.inventory_tabs.key.toggle_tabs": "Toggle Tab Visibility",
   "gui.inventory_tabs.tab.inventory": "Inventory"
 }

--- a/src/main/resources/assets/inventory_tabs/lang/en_us.json
+++ b/src/main/resources/assets/inventory_tabs/lang/en_us.json
@@ -1,7 +1,7 @@
 {
   "key.inventory_tabs.key.next_tab": "Next Tab",
   "key.inventory_tabs.key.toggle_tabs": "Toggle Tab Visibility",
-  "toast.inventory_tabs.disabled.title": "Tabs Disabled",
+  "toast.inventory_tabs.disabled.title": "Inventory Tabs Disabled",
   "toast.inventory_tabs.disabled.key_hint": "[Press %s to toggle]",
   "gui.inventory_tabs.tab.inventory": "Inventory"
 }

--- a/src/main/resources/inventory_tabs.accesswidener
+++ b/src/main/resources/inventory_tabs.accesswidener
@@ -2,8 +2,8 @@ accessWidener v2 named
 accessible method net/minecraft/block/ShulkerBoxBlock canOpen (Lnet/minecraft/block/BlockState;Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/entity/ShulkerBoxBlockEntity;)Z
 mutable field net/minecraft/client/gui/screen/Screen title Lnet/minecraft/text/Text;
 accessible field net/minecraft/client/gui/screen/Screen textRenderer Lnet/minecraft/client/font/TextRenderer;
-accessible field net/minecraft/client/gui/screen/ingame/HandledScreen backgroundWidth I
 accessible field net/minecraft/client/gui/screen/ingame/HandledScreen backgroundHeight I
+accessible field net/minecraft/client/gui/screen/ingame/HandledScreen backgroundWidth I
 mutable field net/minecraft/client/gui/screen/ingame/HandledScreen playerInventoryTitle Lnet/minecraft/text/Text;
 accessible field net/minecraft/client/gui/screen/ingame/HandledScreen x I
 accessible field net/minecraft/client/gui/screen/ingame/HandledScreen y I


### PR DESCRIPTION
Adds a key (default `[`) that toggles tab visibility and functionality. Also displays a toast hint when disabling tabs.
Closes #28 