### PR TITLE
Fix raycast false negatives 

### DIFF
--- a/src/main/java/folk/sisby/inventory_tabs/TabManager.java
+++ b/src/main/java/folk/sisby/inventory_tabs/TabManager.java
@@ -2,6 +2,7 @@ package folk.sisby.inventory_tabs;
 
 import folk.sisby.inventory_tabs.duck.InventoryTabsScreen;
 import folk.sisby.inventory_tabs.tabs.*;
+import folk.sisby.inventory_tabs.util.BlockLineOfSightTimerUtil;
 import folk.sisby.inventory_tabs.util.HandlerSlotUtil;
 import folk.sisby.inventory_tabs.util.WidgetPosition;
 import net.minecraft.block.entity.BlockEntity;
@@ -80,6 +81,7 @@ public class TabManager {
     }
 
     public static void tick(ClientWorld world) {
+        BlockLineOfSightTimerUtil.tick();
         if (holdTabCooldown > 0) {
             if (InputUtil.isKeyPressed(MinecraftClient.getInstance().getWindow().getHandle(), InventoryTabs.NEXT_TAB.boundKey.getCode())) {
                 holdTabCooldown--;

--- a/src/main/java/folk/sisby/inventory_tabs/util/BlockLineOfSightTimerUtil.java
+++ b/src/main/java/folk/sisby/inventory_tabs/util/BlockLineOfSightTimerUtil.java
@@ -1,0 +1,49 @@
+package folk.sisby.inventory_tabs.util;
+
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class BlockLineOfSightTimerUtil {
+    // Timeouts are technically not necessary, but it helps reduce flicker in case
+    // the stored offset becomes obstructed while the block itself is still in line
+    // of sight; though, the flicker is only a thing if you get very unlucky in the
+    // random offset generation. 4 ticks are probably more than enough.
+    private static final int BLOCK_LOS_TIMEOUT_TICKS = 4;
+    public static List<BlockLosTimer> blockLosTimers = new ArrayList<>();
+
+    public static void tick() {
+        blockLosTimers.forEach(BlockLosTimer::tickTimer);
+        blockLosTimers.removeIf(timer -> timer.ticksTillTimeout <= 0);
+    }
+
+    public static class BlockLosTimer {
+        public final BlockPos pos;
+        public int ticksTillTimeout = BLOCK_LOS_TIMEOUT_TICKS;
+        private boolean isInLosThisTick = true;
+        public Vec3d lastViableOffset = null;
+
+        BlockLosTimer(BlockPos pos) {
+            this.pos = pos;
+            blockLosTimers.add(this);
+        }
+
+        private void tickTimer() {
+            ticksTillTimeout = isInLosThisTick ? BLOCK_LOS_TIMEOUT_TICKS : ticksTillTimeout - 1;
+            isInLosThisTick = false;
+        }
+    }
+
+    public static void refreshBlockLosTimer(BlockPos pos, Vec3d offset) {
+        BlockLosTimer timer = Objects.requireNonNullElseGet(getBlockLosTimer(pos), () -> new BlockLosTimer(pos));
+        timer.lastViableOffset = offset;
+        timer.isInLosThisTick = true;
+    }
+
+    public static BlockLosTimer getBlockLosTimer(BlockPos pos) {
+        return blockLosTimers.stream().filter(timer -> timer.pos.equals(pos)).findFirst().orElse(null);
+    }
+}

--- a/src/main/java/folk/sisby/inventory_tabs/util/PlayerUtil.java
+++ b/src/main/java/folk/sisby/inventory_tabs/util/PlayerUtil.java
@@ -36,11 +36,12 @@ public class PlayerUtil {
     }
 
     public static BlockHitResult raycast(PlayerEntity player, BlockPos pos) {
-        List<Vec3d> blockOffsets = generateRandomVec3dList(9, new Vec3d(0.0D, 0.0D, 0.0D), new Vec3d(1.0D, 1.0D, 1.0D));
+        List<Vec3d> blockOffsets = new ArrayList<>();
         BlockLosTimer blockLosTimer = getBlockLosTimer(pos);
         if (blockLosTimer != null && blockLosTimer.lastViableOffset != null) {
             blockOffsets.add(blockLosTimer.lastViableOffset);
         }
+        blockOffsets.addAll(generateRandomVec3dList(9, new Vec3d(0.0D, 0.0D, 0.0D), new Vec3d(1.0D, 1.0D, 1.0D)));
         for (Vec3d offset : blockOffsets) {
             BlockHitResult hitResult = player.getWorld().raycast(new RaycastContext(player.getEyePos(), Vec3d.of(pos).add(offset), RaycastContext.ShapeType.OUTLINE, RaycastContext.FluidHandling.NONE, player));
             if (hitResult.getType() != HitResult.Type.MISS && hitResult.getBlockPos().equals(pos)) {

--- a/src/main/java/folk/sisby/inventory_tabs/util/PlayerUtil.java
+++ b/src/main/java/folk/sisby/inventory_tabs/util/PlayerUtil.java
@@ -12,22 +12,15 @@ import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.RaycastContext;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
+
+import static folk.sisby.inventory_tabs.util.BlockLineOfSightTimerUtil.*;
 
 public class PlayerUtil {
     public static final int REACH = 5;
     public static final double BLOCK_REACH_SQUARE = REACH * REACH;
-    public static final List<Vec3d> BLOCK_OFFSETS = List.of(
-            new Vec3d(0.5D, 0.5D, 0.5D),
-            new Vec3d(0.2D, 0.2D, 0.2D),
-            new Vec3d(0.8D, 0.2D, 0.2D),
-            new Vec3d(0.2D, 0.8D, 0.2D),
-            new Vec3d(0.2D, 0.2D, 0.8D),
-            new Vec3d(0.8D, 0.8D, 0.2D),
-            new Vec3d(0.2D, 0.8D, 0.8D),
-            new Vec3d(0.8D, 0.2D, 0.8D),
-            new Vec3d(0.8D, 0.8D, 0.8D)
-    );
 
     public static boolean inRange(PlayerEntity player, BlockPos pos) {
         if (pos.toCenterPos().squaredDistanceTo(player.getEyePos()) > BLOCK_REACH_SQUARE) return false;
@@ -43,14 +36,38 @@ public class PlayerUtil {
     }
 
     public static BlockHitResult raycast(PlayerEntity player, BlockPos pos) {
-        for (Vec3d offset : BLOCK_OFFSETS) {
+        List<Vec3d> blockOffsets = generateRandomVec3dList(9, new Vec3d(0.0D, 0.0D, 0.0D), new Vec3d(1.0D, 1.0D, 1.0D));
+        BlockLosTimer blockLosTimer = getBlockLosTimer(pos);
+        if (blockLosTimer != null && blockLosTimer.lastViableOffset != null) {
+            blockOffsets.add(blockLosTimer.lastViableOffset);
+        }
+        for (Vec3d offset : blockOffsets) {
             BlockHitResult hitResult = player.getWorld().raycast(new RaycastContext(player.getEyePos(), Vec3d.of(pos).add(offset), RaycastContext.ShapeType.OUTLINE, RaycastContext.FluidHandling.NONE, player));
-            if (hitResult.getType() != HitResult.Type.MISS && hitResult.getBlockPos().equals(pos)) return hitResult;
+            if (hitResult.getType() != HitResult.Type.MISS && hitResult.getBlockPos().equals(pos)) {
+                refreshBlockLosTimer(pos, offset);
+                return hitResult;
+            }
         }
         return BlockHitResult.createMissed(player.getPos(), Direction.EAST, player.getBlockPos());
     }
 
     public static EntityHitResult raycast(PlayerEntity player, Entity entity) {
         return ProjectileUtil.raycast(player, player.getEyePos(), entity.getPos(), player.getBoundingBox().stretch(entity.getRotationVec(1.0F).multiply(REACH)).expand(1.0, 1.0, 1.0), e -> true, BLOCK_REACH_SQUARE);
+    }
+
+    public static List<Vec3d> generateRandomVec3dList(int count, Vec3d min, Vec3d max) {
+        List<Vec3d> list = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            list.add(generateRandomVec3d(min, max));
+        }
+        return list;
+    }
+
+    private static Vec3d generateRandomVec3d(Vec3d min, Vec3d max) {
+        Random random = new Random();
+        double x = min.x + (max.x - min.x) * random.nextDouble();
+        double y = min.y + (max.y - min.y) * random.nextDouble();
+        double z = min.z + (max.z - min.z) * random.nextDouble();
+        return new Vec3d(x, y, z);
     }
 }


### PR DESCRIPTION
Fixes #40.
This fix should drastically reduce the number of false negatives by exploring random offset points over a few ticks for the raycast. 
Theoretically, it should also give a slight performance boost since the random raycasts are only done when necessary (the old offset point becomes obstructed).

A slight caveat is that the time necessary to register the blocks is proportional to the exposed screenspace surface area. Empirically, this is <20 ticks for the worst cases. Scenarios that the original method could have taken care of incur no extra time penalties.